### PR TITLE
Add VS Code settings for eslint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+    "eslint.validate": [
+        "javascript",
+        "javascriptreact",
+        "typescript",
+        "typescriptreact"
+    ],
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true,
+    },
+    "editor.formatOnSave": false
+}


### PR DESCRIPTION
These settings will make sure the file conforms to eslint when saving in VS Code, so you can avoid its wrath when deploying.