### PR TITLE
disable private and friends post radio buttons

### DIFF
--- a/src/components/ManagePost.vue
+++ b/src/components/ManagePost.vue
@@ -9,7 +9,7 @@
         placeholder="Write a title for your post"
       />
       <span id="privacySettings">
-        <input
+        <input disabled
           type="radio"
           name="privacy"
           id="private"
@@ -17,7 +17,7 @@
           v-model="post.visibility"
         />
         <label for="private">Private</label>
-        <input
+        <input disabled
           type="radio"
           name="privacy"
           id="friendsonly"

--- a/src/components/ManagePost.vue
+++ b/src/components/ManagePost.vue
@@ -86,7 +86,7 @@ export default {
         image: null,
         count: 0,
         unlisted: false,
-        visibility: 'PRIVATE',
+        visibility: 'PUBLIC', //Public by default for now
         author: this.author,
         // Generate when post is submitted
         comments: null, // url from server

--- a/src/components/ManagePost.vue
+++ b/src/components/ManagePost.vue
@@ -86,7 +86,7 @@ export default {
         image: null,
         count: 0,
         unlisted: false,
-        visibility: 'PUBLIC', //Public by default for now
+        visibility: 'PUBLIC', // Public by default for now
         author: this.author,
         // Generate when post is submitted
         comments: null, // url from server


### PR DESCRIPTION
Private and friends posts are not implemented on backend, so disabling those radio buttons for now.