### PR TITLE
Pinia refactor and userStore fixes

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -63,7 +63,6 @@ export default {
   beforeMount () {
     // this.getProfilePicture()
     this.userStore.initializeStore() // initialize user store
-    console.log(this.userStore.user)
   },
   methods: {
     logout () {

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -80,9 +80,7 @@ export default {
   computed: {
     ...mapStores(useTokenStore, useUserStore),
     getDisplayName () { // get display name from user store
-      const userStore = useUserStore()
-      userStore.initializeStore()
-      const user = userStore.user
+      const user = this.userStore.getUser()
       if (user.author) {
         return user.author.displayName
       } else {
@@ -91,9 +89,7 @@ export default {
       }
     },
     getProfilePicture () { // get profile picture from user store
-      const userStore = useUserStore()
-      userStore.initializeStore()
-      const user = userStore.user
+      const user = this.userStore.getUser()
       if (user.author) {
         return user.author.profileImage
       } else {

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -54,6 +54,8 @@
 import { useTokenStore } from '@/stores/token'
 import { useUserStore } from '@/stores/user'
 import axios from 'axios'
+import { mapStores } from 'pinia'
+
 export default {
   // Author json object
   methods: {
@@ -61,12 +63,12 @@ export default {
       // post to remove token from server
       axios.post('token/logout').then(response => {
         console.log(response)
-        const token = useTokenStore()
+        const token = this.tokenStore
         token.removeToken() // remove token from store
         localStorage.removeItem('token') // remove token from local
         // remove user from local storage and store
         localStorage.removeItem('user')
-        useUserStore().removeUser()
+        this.userStore.removeUser()
         this.$router.push('/login') // go to login page
         // reset axios header
         axios.defaults.headers.common.Authorization = ''
@@ -76,6 +78,7 @@ export default {
     }
   },
   computed: {
+    ...mapStores(useTokenStore, useUserStore),
     getDisplayName () { // get display name from user store
       const userStore = useUserStore()
       userStore.initializeStore()
@@ -123,7 +126,6 @@ export default {
     object-fit: cover;
     border-radius: 50%;
 }
-
 
 .user-info {
   margin: 0 3pt;

--- a/src/components/settingsComponents/SettingsProfile.vue
+++ b/src/components/settingsComponents/SettingsProfile.vue
@@ -77,16 +77,15 @@ export default {
         displayName: 'Display name',
         profileImage: 'Profile image'
       }
-      const userStore = useUserStore()
-      userStore.initializeStore()
-      const user = userStore.user
-      const author = userStore.user.author
+      this.userStore.initializeStore()
+      const user = this.userStore.user
+      const author = user.author
       author[type] = newValue
       axios.post('/authors/' + author.id + '/', author)
         .then((response) => {
           console.log(response)
           this.showAlert(readableFieldNames[type] + ' sucessfully updated!', 'success')
-          localStorage.setItem('user', JSON.stringify(user)) // update local storage
+          this.userStore.setUser(user) // update user store and local storage
         })
         .catch((error) => {
           console.log(error)
@@ -95,6 +94,7 @@ export default {
     }
   },
   computed: {
+    ...mapStores(useUserStore),
     getDisplayName () { // get display name from user store
       return this.getUser().author.displayName
     },

--- a/src/components/settingsComponents/SettingsProfile.vue
+++ b/src/components/settingsComponents/SettingsProfile.vue
@@ -6,13 +6,18 @@
   <h2>Settings</h2>
   <div class="d-flex justify-content-center">
   <div class="d-flex">
+    <!-- Profile picture and the edit overlay that shows on hover-->
     <div class="image-container">
-  <img class = "settings-profile-image rounded-circle" :src="getProfileImage" alt = 'User profile picture'/>
+  <img class = "settings-profile-image rounded-circle" :src="getAuthorPropertyIfDefined('profileImage')" alt = 'User profile picture'/>
   <div class="edit-overlay rounded-circle" role="button" @click="promptImageURL"><i class="bi bi-pencil-fill overlay-icon"></i></div>
 </div>
+    <!-- Settings for names and password -->
   <div class="d-flex flex-column p-4 text-start">
-  <div><span class="display-name">Display Name: @{{ getDisplayName }}</span>&nbsp;<i class="bi bi-pencil-fill"  role="button" @click="promptNewDisplayName"></i></div>
-<div><span class="username">Username: {{ getUsername }}</span>&nbsp;<UsernameChangeModal @alert="showAlert"></UsernameChangeModal></div>
+    <!-- Display name field with clickable edit icon -->
+  <div><span class="display-name">Display Name: @{{ getAuthorPropertyIfDefined('displayName') }}</span>&nbsp;<i class="bi bi-pencil-fill"  role="button" @click="promptNewDisplayName"></i></div>
+  <!-- Username field with clickable edit icon -->
+<div><span class="username">Username: {{ this.userStore.user.username }}</span>&nbsp;<UsernameChangeModal @alert="showAlert"></UsernameChangeModal></div>
+<!-- Change password botton -->
   <PasswordChangeModal @alert="showAlert"></PasswordChangeModal>
 </div>
 
@@ -42,15 +47,6 @@ export default {
     }
   },
   methods: {
-    getUser () {
-      const user = this.userStore.getUser()
-      if (user) {
-        return user
-      } else {
-        console.log('could not retrieve author property')
-        return null
-      }
-    },
     showAlert (msg, type) {
       this.alert.msg = msg
       this.alert.type = 'alert-' + type
@@ -90,19 +86,13 @@ export default {
           console.log(error)
           this.showAlert(readableFieldNames[type] + ' update failed!', 'danger')
         })
+    },
+    getAuthorPropertyIfDefined (prop) {
+      return this.userStore.user.author ? this.userStore.user.author[prop] : '' // return an author property only if author exists else return empty string
     }
   },
   computed: {
-    ...mapStores(useUserStore),
-    getDisplayName () { // get display name from user store
-      return this.getUser().author.displayName
-    },
-    getProfileImage () { // get profile picture from user store
-      return this.getUser().author.profileImage
-    },
-    getUsername () {
-      return this.getUser().username
-    }
+    ...mapStores(useUserStore)
 
   }
 

--- a/src/components/settingsComponents/SettingsProfile.vue
+++ b/src/components/settingsComponents/SettingsProfile.vue
@@ -25,6 +25,7 @@
 import { useUserStore } from '@/stores/user'
 import PasswordChangeModal from '@/components/settingsComponents/PasswordChangeModal.vue'
 import UsernameChangeModal from './UsernameChangeModal.vue'
+import { mapStores } from 'pinia'
 import axios from 'axios'
 export default {
   name: 'SettingsProfile',
@@ -42,9 +43,7 @@ export default {
   },
   methods: {
     getUser () {
-      const userStore = useUserStore()
-      userStore.initializeStore()
-      const user = userStore.user
+      const user = this.userStore.getUser()
       if (user) {
         return user
       } else {

--- a/src/components/settingsComponents/UsernameChangeModal.vue
+++ b/src/components/settingsComponents/UsernameChangeModal.vue
@@ -35,6 +35,7 @@
 import axios from 'axios'
 import { errorToString } from '@/util/authErrorHandler'
 import { useUserStore } from '@/stores/user'
+import { mapStores } from 'pinia'
 export default {
   name: 'UsernameChangeModal',
   emits: ['alert'],
@@ -84,12 +85,15 @@ export default {
       this.$emit('alert', 'Username changed successfully. Your username is now "' + newName + '".', 'success')
     },
     updateLocalUsername (newUsername) {
-      const userStore = useUserStore()
+      const userStore = this.userStore
       userStore.initializeStore()
       const user = userStore.user
       user.username = newUsername
       localStorage.setItem('user', JSON.stringify(userStore.user))
     }
+  },
+  computed: {
+    ...mapStores(useUserStore)
   }
 }
 

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -15,9 +15,15 @@ export const useUserStore = defineStore('user', {
     setUser (user) { // set the user in local storage when the user logs in
       console.assert(typeof user === 'object', 'user must be an object')
       this.user = user
+      localStorage.setItem('user', JSON.stringify(user))
     },
     removeUser () { // remove the user from local storage when the user logs out
       this.user = {}
+      localStorage.removeItem('user')
+    },
+    getUser () {
+      this.initializeStore()
+      return this.user
     }
   }
 })

--- a/src/views/Browse.vue
+++ b/src/views/Browse.vue
@@ -75,6 +75,7 @@
 import Post from '../components/RevisedCard.vue'
 import axios from 'axios'
 import { useUserStore } from '@/stores/user'
+import { mapStores } from 'pinia'
 const moment = require('moment')
 
 export default {
@@ -91,6 +92,7 @@ export default {
     }
   },
   computed: {
+    ...mapStores(useUserStore),
     postSections () {
       const sections = []
       const groupedPosts = this.posts.reduce((acc, post) => {
@@ -133,7 +135,7 @@ export default {
         })
     },
     getAuthorFromStore () {
-      const userStore = useUserStore()
+      const userStore = this.userStore
       userStore.initializeStore()
       this.author = userStore.user.author
     }

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -15,9 +15,10 @@
 
 <script>
 import { useTokenStore } from '@/stores/token'
-import { useUserStore } from '@/stores/user'
 import axios from 'axios'
 import { errorToString } from '@/util/authErrorHandler'
+import { useUserStore } from '@/stores/user'
+import { mapStores } from 'pinia'
 export default {
   name: 'LogIn',
   data () {
@@ -56,9 +57,8 @@ export default {
             .then(response => {
               this.authError = '' // clear error message
               const user = response.data
-              const store = useUserStore()
+              const store = this.userStore
               store.setUser(user)
-              localStorage.setItem('user', JSON.stringify(user))
             })
             .catch(error => {
               console.log(error)
@@ -76,6 +76,9 @@ export default {
         })
     }
 
+  },
+  computed: {
+    ...mapStores(useTokenStore, useUserStore)
   }
 }
 

--- a/src/views/ManagePostsView.vue
+++ b/src/views/ManagePostsView.vue
@@ -48,6 +48,7 @@ import ManagePost from '@/components/ManagePost.vue'
 import Card from '@/components/RevisedCard.vue'
 import PopUpPrompt from '@/components/PopUpPrompt.vue'
 import { useUserStore } from '@/stores/user'
+import { mapStores } from 'pinia'
 import axios from 'axios'
 
 export default {
@@ -59,6 +60,9 @@ export default {
       showPrompt: false,
       author: null
     }
+  },
+  computed: {
+    ...mapStores(useUserStore)
   },
   methods: {
     deletePost () {
@@ -115,7 +119,7 @@ export default {
     },
 
     getAuthorFromStore () {
-      const userStore = useUserStore()
+      const userStore = this.userStore
       userStore.initializeStore()
       this.author = userStore.user.author
     }

--- a/src/views/SignUp.vue
+++ b/src/views/SignUp.vue
@@ -49,7 +49,6 @@ export default {
           .then(response => {
             this.$router.push('/login') // redirect to login page
             console.log(response)
-            console.log(formData.password)
           })
           .catch(error => {
             console.log(error)

--- a/tests/unit/NavBar.spec.js
+++ b/tests/unit/NavBar.spec.js
@@ -40,7 +40,7 @@ describe('NavBar.vue', () => {
   it('renders the author name', () => {
     wrapper = shallowMount(NavBar)
     const author = useUserStore().user.author
-    const username = wrapper.get('#username')
+    const username = wrapper.get('#display-name')
     expect(username.text()).toMatch('@' + author.displayName)
   })
 
@@ -74,5 +74,25 @@ describe('NavBar.vue', () => {
     // both shallow mounting (can't find) and regular mounting (undefined error)
 
     // expect(wrapper.findAll('li .active').length).toBe(1)
+  })
+  it('updates displayname when it changes', async () => {
+    const user = useUserStore().user
+    const newDisplayName = 'Squirtle'
+    user.author.displayName = newDisplayName // change the user's display name
+    useUserStore().setUser(user) // update the user in the store
+    wrapper = shallowMount(NavBar)
+    await wrapper.vm.$nextTick()
+    const displayName = wrapper.get('#display-name')
+    expect(displayName.text()).toMatch('@' + newDisplayName) // check that the display name has changed
+  })
+  it('updates profile image when it changes', async () => {
+    const user = useUserStore().user
+    const newProfileImage = 'https://assets.pokemon.com/assets/cms2/img/pokedex/full/007.png' // squirtle image
+    user.author.profileImage = newProfileImage // change the user's profile image
+    useUserStore().setUser(user) // update the user in the store
+    wrapper = shallowMount(NavBar)
+    await wrapper.vm.$nextTick()
+    const profileImage = wrapper.get('img')
+    expect(profileImage.attributes().src).toEqual(newProfileImage) // check that the profile image has changed
   })
 })


### PR DESCRIPTION
## Changes
### General
- Refactored all uses of `useUserStore()` to `this.userStore` using `mapStores()`, as recommended for the options API in the [documentation](https://pinia.vuejs.org/cookbook/options-api.html)
### userStore (user.js)
- Added a getter to the user store in user.js
- Added localStorage operations to all methods, so you no longer need to call `initializeStore()` before getting a user if using `getUser()`
### Manage profile
- Fixed bug where the profile image in manage profile would not update if changed twice in a row
- 021c84b FINALLY fixes bug where profile image and display name would not update if changed unless the page was refreshed 🎉
  - Two unit tests were added to test profile image and display name changes

