### PR TITLE
Scoped styles of social components

### DIFF
--- a/src/components/socialComponents/MyFollowees.vue
+++ b/src/components/socialComponents/MyFollowees.vue
@@ -54,7 +54,7 @@ export default {
 
 </script>
 
-  <style>
+  <style scoped>
   /* list items that are direct children of unordered list*/
   .list-of-profiles ul>li{
     display: inline-block

--- a/src/components/socialComponents/MyFollowers.vue
+++ b/src/components/socialComponents/MyFollowers.vue
@@ -53,7 +53,7 @@ export default {
 
 </script>
 
-<style>
+<style scoped>
 
   .list-of-profiles ul>li{
     display: inline-block

--- a/src/components/socialComponents/MyFriends.vue
+++ b/src/components/socialComponents/MyFriends.vue
@@ -54,7 +54,7 @@ export default {
 
 </script>
 
-  <style>
+  <style scoped>
 
   .list-of-profiles ul>li{
     display: inline-block

--- a/src/components/socialComponents/MyRequests.vue
+++ b/src/components/socialComponents/MyRequests.vue
@@ -56,7 +56,7 @@ export default {
 
 </script>
 
-  <style>
+  <style scoped>
 
   .list-of-profiles ul>li{
     display: inline-block


### PR DESCRIPTION
Avoids the css interfering with the style of other images, which was causing the wide profile pic in the navbar among other issues. See https://vuejs.org/api/sfc-css-features.html#scoped-css for an explanation.
Before:
![image](https://user-images.githubusercontent.com/38046772/226148723-c72897db-d871-4398-bba6-959315d7f037.png)
After:
![image](https://user-images.githubusercontent.com/38046772/226148715-50ffea96-0ad7-4a91-a85c-66baf335a140.png)
