### PR TITLE
use origin when getting post info in single post

### DIFF
--- a/src/components/PostCard.vue
+++ b/src/components/PostCard.vue
@@ -5,7 +5,7 @@
   @hovered="hovered=true"
   @unhover="hovered=false"
   :title="post.title"
-  :anchor="{ name: 'postpage', params: { aid: this.author._id, pid: this.post._id } }">
+  :anchor="{ name: 'postpage', params: { aid: this.author._id, pid: this.post._id}, query : { origin: this.post.origin} }">
 
     <template #card-content>
       <vue-markdown
@@ -64,11 +64,6 @@ export default {
     },
     isSingleton () {
       return (!!this.post.image && !this.post.content) || (!this.post.image && !!this.post.content)
-    }
-  },
-  methods: {
-    goTo () {
-      this.$router.push({ name: 'postpage', params: { aid: this.author._id, pid: this.post._id } })
     }
   }
 }

--- a/src/views/SinglePostView.vue
+++ b/src/views/SinglePostView.vue
@@ -157,28 +157,29 @@ export default {
     getAxiosTarget () {
       // get origin from query
       const origin = this.$route.query.origin
-      const theRealOrigin = origin === 'http://anotherplaceholderurlfornow.yucky' ? 'https://social-t30.herokuapp.com' : origin // stop gap for old posts with bad origin
+      const theRealOrigin = origin.includes('http://anotherplaceholderurlfornow.yucky') ? 'https://social-t30.herokuapp.com' : origin // stop gap for old posts with bad origin
       const hostname = new URL(theRealOrigin).hostname // get hostname from origin
-      const myBaseURL = hostname + '/api/' // append api
+      console.log(hostname)
+      const myBaseURL = 'http://' + hostname + '/api/' // append api
       const axiosTarget = axios.create({
         baseURL: myBaseURL
       })
       return axiosTarget
     },
     async getData (pid, aid) {
-      this.getAxiosTarget().get(`/authors/${aid}/posts/${pid}`)
+      this.getAxiosTarget().get(`/authors/${aid}/posts/${pid}/`)
         .then((res) => {
           this.postData = res.data
         })
         .catch((err) => { console.log(err) })
 
-      this.getAxiosTarget().get(`/authors/${aid}`)
+      this.getAxiosTarget().get(`/authors/${aid}/`)
         .then((res) => {
           this.authorData = res.data
         })
         .catch((err) => { console.log(err) })
 
-      this.getAxiosTarget().get(`/authors/${aid}/friends`)
+      this.getAxiosTarget().get(`/authors/${aid}/friends/`)
         .then((res) => {
           this.friends = res.data.items
           this.friendsLoading = false


### PR DESCRIPTION
Before, we would just use our own host when getting post info in single post. This theoretically allows us to view remote posts from the inbox, by clicking on them. Right now this works with local posts.

To-do:

- [ ] Retrieve token for remote hosts from the backend