### PR TITLE
fix positioning of sidebar in singlePostView

### DIFF
--- a/src/components/viewPostComponents/SinglePost.vue
+++ b/src/components/viewPostComponents/SinglePost.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="post-template container">
+  <div class="post-template">
     <section class="post-title">
       <h1 class = post-title>{{post.title}}</h1>
     </section>

--- a/src/views/SinglePostView.vue
+++ b/src/views/SinglePostView.vue
@@ -1,8 +1,5 @@
 <template>
-    <div class="d-flex flex-column flex-shrink-0" id="single-post-container">
-      <!-- Components: Post, Comments list, profile picture -->
-      <PostProper v-if="!loading" :post="postData" :author="authorData" class="col-9"></PostProper>
-
+    <div class="d-flex flex-shrink-0" id="single-post-container">
       <!--Left sidebar w/ features and author stuff-->
       <aside v-if="!loading" class="post-left-bar">
         <section class="author-info">
@@ -32,6 +29,8 @@
           </li>
         </ul>
       </aside>
+      <!-- Components: Post, Comments list, profile picture -->
+      <PostProper v-if="!loading" :post="postData" :author="authorData" class="col-9"></PostProper>
 
       <!-- Right comment aside -->
       <aside v-if="!loading" class="post-right-bar" :class="{expanded: expandComments}">
@@ -328,6 +327,7 @@ export default {
   /* Left aside */
 
   .post-left-bar {
+
     display: flex;
     flex-direction: column;
     justify-content: space-evenly;
@@ -391,7 +391,7 @@ export default {
   }
 
   aside {
-    position: fixed;
+    position: relative;
     width: min(20%, fit-content);
   }
 
@@ -402,6 +402,7 @@ export default {
 
   /* Right aside */
   .post-right-bar {
+    position: fixed;
     right: 0;
     background-color: rgba(0,0,0,0.7);
     height: 100%;

--- a/src/views/SinglePostView.vue
+++ b/src/views/SinglePostView.vue
@@ -344,8 +344,8 @@ export default {
   }
   .author-picture {
     border-radius: 50%;
-    width: 144pt;
-    height: 144pt;
+    width: 128pt;
+    height: 128pt;
   }
 
   .btn-with-label {


### PR DESCRIPTION
Fix positioning of sidebar in singlePostView, so it doesn't overlap with post content at smaller resolutions. 
Also reduced the size of the profile image and fixed the margins on post content, so sidebar doesn't get pushed to the left at smaller resolutions