### PR TITLE
GitHub feed fixes

### DIFF
--- a/src/components/inboxComponents/GitHubList.vue
+++ b/src/components/inboxComponents/GitHubList.vue
@@ -64,9 +64,12 @@ export default {
     parseEvent (event) {
       const parseGithubEvent = require('parse-github-event')
       const parsedEvent = parseGithubEvent.parse(event)
+      if (parsedEvent) {
       const eventText = parseGithubEvent.compile(parsedEvent)
+        return eventText
+      }
+      return `${event.actor.display_login} did a ${event.type.replace('Event', '')} in ${event.repo.name}`
       // console.log(parsedEvent)
-      return eventText
     }
   }
 }

--- a/src/components/inboxComponents/GitHubList.vue
+++ b/src/components/inboxComponents/GitHubList.vue
@@ -12,20 +12,23 @@
 
         <template #card-content>
         <div class="text-center">
-          <p> {{ parseEvent(event) }}</p>
+          <p class="gh-event-text"> {{ parseEvent(event) }}</p>
         </div>
 
         </template>
         <template #footer>
-          <img class="profile-image ms-2" :src="event.actor.avatar_url" :class="{ open: hovered }" :title="event.actor.display_login + '\'s GitHub image'" />
+          <a :href = "'https://github.com/' + event.actor.display_login" target="_blank">
+            <img class="profile-image ms-2" :src="event.actor.avatar_url" :class="{ open: hovered }" :title="event.actor.display_login + '\'s GitHub image'" />
+          </a>
           <div class="d-flex align-items-center justify-content-between w-100 h-100 px-3 overflow-hidden">
-
           <div>
-          {{ event.actor.display_login }}
+            <a :href = "'https://github.com/' + event.actor.display_login" target="_blank">{{ event.actor.display_login }}</a>
           </div>
-          <a :href = "'https://github.com/' + event.actor.login" target="_blank">
-          <i class="bi bi-github" title="Visit GitHub profile"></i>
-            </a>
+          <div class="d-flex gap-2">
+          <a :href = "'https://github.com/' + event.repo.name" target="_blank"><i class="bi bi-journal-code gh-card-icon"></i>
+         </a>
+
+          </div>
         </div>
 
         </template>
@@ -65,10 +68,12 @@ export default {
       const parseGithubEvent = require('parse-github-event')
       const parsedEvent = parseGithubEvent.parse(event)
       if (parsedEvent) {
-      const eventText = parseGithubEvent.compile(parsedEvent)
+        const eventText = parseGithubEvent.compile(parsedEvent)
         return eventText
       }
-      return `${event.actor.display_login} did a ${event.type.replace('Event', '')} in ${event.repo.name}`
+      // handle unknown events
+      const humanReadableEvent = event.type.replace('Event', '').replace(/([A-Z])/g, ' $1').toLowerCase() // add spaces before capital letters and convert to lowercase
+      return `${event.actor.display_login} did a ${humanReadableEvent} in ${event.repo.name}`
       // console.log(parsedEvent)
     }
   }
@@ -93,7 +98,7 @@ export default {
   a:hover {
     color: #4998f5
   }
-  .bi-github {
+  .bi {
     font-size: 1.5em;
   }
 

--- a/src/views/InboxView.vue
+++ b/src/views/InboxView.vue
@@ -25,7 +25,7 @@
         <h1 class="mt-5 text-left"> Your <strong>GitHub Events Feed</strong> </h1>
         <GitHubList v-if="!loading && stream_gh.items?.length > 0" :selectedNotifications="stream_gh.items" class="list pb-2"></GitHubList>
         <!-- If error loading GitHub feed -->
-        <p v-if="gh_error" class="mt-3 mb-1 text-danger">{{gh_error}}</p>
+        <div v-if="gh_error" class="alert alert-danger" role="alert">{{gh_error}}</div>
         <!-- Show more button for GitHub feed -->
         <ShowMoreButton v-if="this.author?.github" @show-more="getGitHubEvents(++stream_gh.page)">
           <span v-if="stream_gh.items?.length == 0">Load feed</span>

--- a/src/views/InboxView.vue
+++ b/src/views/InboxView.vue
@@ -24,6 +24,8 @@
     <div class="github-container  w-100">
         <h1 class="mt-5 text-left"> Your <strong>GitHub Events Feed</strong> </h1>
         <GitHubList v-if="!loading && stream_gh.items?.length > 0" :selectedNotifications="stream_gh.items" class="list pb-2"></GitHubList>
+        <!-- If error loading GitHub feed -->
+        <p v-if="gh_error" class="mt-3 mb-1 text-danger">{{gh_error}}</p>
         <!-- Show more button for GitHub feed -->
         <ShowMoreButton v-if="this.author?.github" @show-more="getGitHubEvents(++stream_gh.page)">
           <span v-if="stream_gh.items?.length == 0">Load feed</span>
@@ -69,7 +71,8 @@ export default {
         page: 0
       },
       author: null,
-      loading: true
+      loading: true,
+      gh_error: ''
     }
   },
   methods: {
@@ -94,6 +97,11 @@ export default {
         })
         .catch((err) => {
           console.log(err)
+          if (err.response.status === 404) {
+            this.gh_error = 'GitHub user not found, please check your GitHub username and try again.'
+          } else if (err.response.status === 403) {
+            this.gh_error = 'GitHub API rate limit exceeded, please try again later.'
+          }
         })
     },
     getInbox (page) {

--- a/src/views/InboxView.vue
+++ b/src/views/InboxView.vue
@@ -27,7 +27,7 @@
         <!-- If error loading GitHub feed -->
         <div v-if="gh_error" class="alert alert-danger" role="alert">{{gh_error}}</div>
         <!-- Show more button for GitHub feed -->
-        <ShowMoreButton v-if="this.author?.github" @show-more="getGitHubEvents(++stream_gh.page)">
+        <ShowMoreButton v-if="this.author?.github && !this.stream_gh.noMore" @show-more="getGitHubEvents(++stream_gh.page)">
           <span v-if="stream_gh.items?.length == 0">Load feed</span>
           <span v-else-if="stream_gh.items?.length > 0">Show more events</span>
           </ShowMoreButton>
@@ -68,7 +68,8 @@ export default {
       stream_gh: {
         items: [],
         size: 10,
-        page: 0
+        page: 0,
+        noMore: false
       },
       author: null,
       loading: true,
@@ -94,10 +95,16 @@ export default {
           console.log(page)
           console.log(res)
           this.stream_gh.items = this.stream_gh.items.concat(res.data)
+          if (res.data.length < this.stream_gh.size) { // if we got less than the max size, we're at the end
+            this.stream_gh.noMore = true
+          }
+          if (this.stream_gh.items.length === 0) {
+            this.gh_error = 'No GitHub events found for this user.'
+          }
         })
         .catch((err) => {
           console.log(err)
-          if (err.response.status === 404) {
+          if (err.response.status === 404 && this.stream_gh.items.length === 0) {
             this.gh_error = 'GitHub user not found, please check your GitHub username and try again.'
           } else if (err.response.status === 403) {
             this.gh_error = 'GitHub API rate limit exceeded, please try again later.'


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/38046772/230312648-ee367bb7-485e-4f64-a61a-f66085bdb30f.png)
* changed up the github card to link to user (click on name or pic) and target repo
* added basic error handling
* handled event that was unknown to the parsing library
