### PR TITLE
#95: add show more button to inbox

### DIFF
--- a/src/components/ShowMoreButton.vue
+++ b/src/components/ShowMoreButton.vue
@@ -6,6 +6,7 @@
 
 <script>
 export default {
+  emits: ['showMore'],
   methods: {
     myOnClick () {
       this.$emit('showMore')

--- a/src/components/inboxComponents/InboxModalBody.vue
+++ b/src/components/inboxComponents/InboxModalBody.vue
@@ -23,20 +23,24 @@
   </div>
 
   <!-- What things are we getting? Posts, comments, all, etc -->
+  <div class="d-flex flex-column align-items-center">
   <NotificationList :selectedNotifications="selectedNotifications"/>
-
+  <ShowMoreButton v-if="!noMore" @show-more="showMore"></ShowMoreButton>
+  <p v-else>No more notifications to show!</p>
+</div>
 </template>
 
 <script>
 
 import NotificationList from '@/components/inboxComponents/NotificationList.vue'
+import ShowMoreButton from '../ShowMoreButton.vue'
 import { useUserStore } from '@/stores/user'
 import { mapStores } from 'pinia'
 
 export default {
-  components: { NotificationList },
-  props: ['allNotifications'],
-
+  components: { NotificationList, ShowMoreButton },
+  props: ['allNotifications', 'noMore'],
+  emits: ['showMore'],
   computed: {
     ...mapStores(useUserStore),
     selectedNotifications () {
@@ -68,6 +72,10 @@ export default {
       const userStore = this.userStore
       userStore.initializeStore()
       this.author = userStore.user.author
+    },
+    showMore () {
+      this.$emit('showMore')
+      console.log('show more')
     }
   }
 }

--- a/src/views/InboxView.vue
+++ b/src/views/InboxView.vue
@@ -4,7 +4,7 @@
     <SlotModal v-if="!loading" modalName="inboxModal" sizing="modal-xl" justification="modal-dialog-centered">
       <template #titleText><h2>Inbox</h2></template>
       <template #body>
-        <InboxModalBody :allNotifications="stream.items"/>
+        <InboxModalBody :allNotifications="stream.items" :no-more="stream.noMore" @show-more="getInbox(++stream.page)"/>
       </template>
       <template #closeButtonText>Done</template>
       <template #openModalButton>
@@ -16,7 +16,7 @@
     <NotificationList v-if="!loading && stream.items?.length > 0" :selectedNotifications="stream.items" class="list pb-2"></NotificationList>
     <p v-else-if="!loading && stream.items?.length === 0">There's nothing here for you yet</p>
     <ShowMoreButton v-if="!loading && stream.items?.length > 0 && !stream.noMore" @show-more="getInbox(++stream.page)">
-      Show more posts
+      Show more
           </ShowMoreButton>
           <!-- if out of items -->
     <p v-else-if="!loading && stream.noMore">No more notifications to show!</p>


### PR DESCRIPTION
Fixes #95 by adding a show more button to the inbox, works with all filters
![image](https://user-images.githubusercontent.com/38046772/230575008-8b6aa5da-ec66-476f-8671-d2e4c91fa4d5.png)
